### PR TITLE
Handle own `'__proto__'` keys consistently

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,12 @@ module.exports = (object, predicate) => {
 
 	for (const [key, value] of Object.entries(object)) {
 		if (isArray ? predicate.includes(key) : predicate(key, value, object)) {
-			result[key] = value;
+			Object.defineProperty(result, key, {
+				value,
+				writable: true,
+				enumerable: true,
+				configurable: true
+			});
 		}
 	}
 

--- a/test.js
+++ b/test.js
@@ -12,3 +12,8 @@ test('array predicate', t => {
 	t.is(filteredKeys[0], 'foo');
 	t.is(filteredKeys.length, 1);
 });
+
+test.failing('__proto__ keys', t => {
+	const input = {['__proto__']: {foo: true}};
+	t.deepEqual(filterObject(input, () => true), input);
+});

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ test('array predicate', t => {
 	t.is(filteredKeys.length, 1);
 });
 
-test.failing('__proto__ keys', t => {
+test('__proto__ keys', t => {
 	const input = {['__proto__']: {foo: true}};
 	t.deepEqual(filterObject(input, () => true), input);
 });


### PR DESCRIPTION
This PR adds a failing test case for `'__proto__'` keys, and then fixes the issue by using `Object.defineProperty()` to create the properties of the result object.

I do not think this is a breaking change.

Fixes #11.