### PR TITLE
Improve performance

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,31 @@
+import filterObj from 'filter-obj';
+
+// Benchmark `filter-obj`.
+// Higher `loopCount` give more precise results but last longer.
+// `objectSize` gives different results based on how big the input object is.
+// `predicateSize` is similar but for predicate arrays. When `undefined`, a predicate function is used instead.
+const benchmark = function (loopCount, objectSize, predicateSize) {
+	const bigObject = Object.fromEntries(Array.from({length: objectSize}, getObjectKeyPair));
+	const predicate = predicateSize === undefined ? isEven : Array.from({length: predicateSize}, getPredicateKey);
+
+	console.time();
+	for (let index = 0; index < loopCount; index += 1) {
+		filterObj(bigObject, predicate);
+	}
+
+	console.timeEnd();
+};
+
+const getObjectKeyPair = function (_, index) {
+	return [`a${index}`, index];
+};
+
+const getPredicateKey = function (_, index) {
+	return `a${index}`;
+};
+
+const isEven = function (key, value) {
+	return value % 2 === 0;
+};
+
+benchmark(1e3, 1e4);

--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ export default function filterObject(object, predicate) {
 			}
 		}
 	} else {
-		for (const [key, value] of Object.entries(object)) {
+		// `for ... of Object.keys()` is faster than `for ... of Object.entries()`.
+		for (const key of Object.keys(object)) {
+			const value = object[key];
 			if (predicate(key, value, object)) {
 				Object.defineProperty(result, key, {
 					value,


### PR DESCRIPTION
This PR improves performance by ~40% (on my machine). The performance improvement seems fairly consistent with both very small and very objects.

Benchmark code:

```js
import filterObj from 'filter-obj'

const bigObject = Object.fromEntries(new Array(1e4).fill().map((_, index) => [`a${index}`, index]))
const predicate = (key, value) => value % 2 === 0

console.time()
for (let i = 0; i < 1e3; i += 1) {
	filterObj(bigObject, predicate)
}
console.timeEnd()
```

The performance improvement is due to avoiding to create an unnecessary array with `Object.entries()`.

I have also opened #13 to ensure this does not change any behavior.