### PR TITLE
Improve performance of array predicates

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,29 @@
 export default function filterObject(object, predicate) {
 	const result = {};
-	const isArray = Array.isArray(predicate);
 
-	for (const [key, value] of Object.entries(object)) {
-		if (isArray ? predicate.includes(key) : predicate(key, value, object)) {
-			Object.defineProperty(result, key, {
-				value,
-				writable: true,
-				enumerable: true,
-				configurable: true,
-			});
+	if (Array.isArray(predicate)) {
+		const set = new Set(predicate);
+		for (const key of Object.keys(object)) {
+			if (set.has(key)) {
+				const value = object[key];
+				Object.defineProperty(result, key, {
+					value,
+					writable: true,
+					enumerable: true,
+					configurable: true,
+				});
+			}
+		}
+	} else {
+		for (const [key, value] of Object.entries(object)) {
+			if (predicate(key, value, object)) {
+				Object.defineProperty(result, key, {
+					value,
+					writable: true,
+					enumerable: true,
+					configurable: true,
+				});
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR improves performance of array predicates by up to 10 times (on my machine).
Benchmark code:

```js
import filterObj from 'filter-obj'

const bigObject = Object.fromEntries(new Array(1e4).fill().map((_, index) => [`a${index}`, index]))
const predicate = new Array(1e3).fill().map((_, index) => `a${index}`)

console.time()
for (let i = 0; i < 1e1; i += 1) {
	filterObj(bigObject, predicate)
}
console.timeEnd()
```

It does it by turning the array into a `Set`. Bigger arrays yield a bigger performance improvement. Surprisingly, even arrays of small length (including 0) are faster, despite the cost of creating a `Set`.

I have also opened https://github.com/sindresorhus/filter-obj/pull/13 to ensure this does not change any behavior.