### PR TITLE
Drop support for Node 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
+          - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+		"node": "^14.19.0 || ^16.15.0 || >=18.0.0"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
This PR drops support for Node 12 (breaking change).
It also adds CI tests for Node 18, and upgrade some GitHub actions.