### PR TITLE
Fix descriptors copy

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,8 @@ export function includeKeys(object, predicate) {
 		const set = new Set(predicate);
 		for (const key of Object.keys(object)) {
 			if (set.has(key)) {
-				const value = object[key];
-				Object.defineProperty(result, key, {
-					value,
-					writable: true,
-					enumerable: true,
-					configurable: true,
-				});
+				const descriptor = Object.getOwnPropertyDescriptor(object, key);
+				Object.defineProperty(result, key, descriptor);
 			}
 		}
 	} else {
@@ -19,12 +14,8 @@ export function includeKeys(object, predicate) {
 		for (const key of Object.keys(object)) {
 			const value = object[key];
 			if (predicate(key, value, object)) {
-				Object.defineProperty(result, key, {
-					value,
-					writable: true,
-					enumerable: true,
-					configurable: true,
-				});
+				const descriptor = Object.getOwnPropertyDescriptor(object, key);
+				Object.defineProperty(result, key, descriptor);
 			}
 		}
 	}

--- a/test.js
+++ b/test.js
@@ -33,6 +33,13 @@ test('includeKeys: non-enumerable properties are omitted', t => {
 	t.is(includeKeys(input, () => true).test, undefined);
 });
 
+test('includeKeys: descriptors are kept as is', t => {
+	const descriptor = {get() {}, set() {}, enumerable: true, configurable: false};
+	const input = Object.defineProperty({}, 'test', descriptor);
+	t.deepEqual(Object.getOwnPropertyDescriptor(includeKeys(input, () => true), 'test'), descriptor);
+	t.deepEqual(Object.getOwnPropertyDescriptor(includeKeys(input, ['test']), 'test'), descriptor);
+});
+
 test('includeKeys: inherited properties are omitted', t => {
 	const Parent = class {
 		test() {}
@@ -77,6 +84,13 @@ test('excludeKeys: symbol properties are omitted', t => {
 test('excludeKeys: non-enumerable properties are omitted', t => {
 	const input = Object.defineProperty({}, 'test', {value: true, enumerable: false});
 	t.is(excludeKeys(input, () => false).test, undefined);
+});
+
+test('excludeKeys: descriptors are kept as is', t => {
+	const descriptor = {get() {}, set() {}, enumerable: true, configurable: false};
+	const input = Object.defineProperty({}, 'test', descriptor);
+	t.deepEqual(Object.getOwnPropertyDescriptor(excludeKeys(input, () => false), 'test'), descriptor);
+	t.deepEqual(Object.getOwnPropertyDescriptor(excludeKeys(input, []), 'test'), descriptor);
 });
 
 test('excludeKeys: inherited properties are omitted', t => {


### PR DESCRIPTION
Fixes #20.

This ensures descriptors properties (`writable`, `configurable`, `get`, `set`) are kept when copying.
Note: we ignore non-enumerable properties, so `enumerable` is always `true`.

This is a bug fix. However, this could arguably be a breaking change for some consumers relying on the current (incorrect) behavior.