### PR TITLE
Do not ignore symbol properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ Filter object keys and values into a new object.
 
 @param object - The source object to filter properties from.
 @param predicate - Predicate function that determines whether a property should be assigned to the new object.
-@param keys - Property names that should be assigned to the new object.
+@param keys - Property keys that should be assigned to the new object.
 
 @example
 ```
@@ -41,7 +41,7 @@ Filter object keys and values into a new object.
 
 @param object - The source object to filter properties from.
 @param predicate - Predicate function that determines whether a property should not be assigned to the new object.
-@param keys - Property names that should not be assigned to the new object.
+@param keys - Property keys that should not be assigned to the new object.
 
 @example
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ const newObject2 = includeKeys(object, ['bar']);
 //=> {bar: false}
 ```
 */
-export function includeKeys<ObjectType extends Record<string, any>>(
+export function includeKeys<ObjectType extends Record<PropertyKey, any>>(
 	object: ObjectType,
 	predicate: (
 		key: keyof ObjectType,
@@ -29,7 +29,7 @@ export function includeKeys<ObjectType extends Record<string, any>>(
 	) => boolean
 ): Partial<ObjectType>;
 export function includeKeys<
-	ObjectType extends Record<string, any>,
+	ObjectType extends Record<PropertyKey, any>,
 	IncludedKeys extends keyof ObjectType,
 >(
 	object: ObjectType,
@@ -59,7 +59,7 @@ const newObject3 = excludeKeys(object, ['bar']);
 //=> {foo: true}
 ```
 */
-export function excludeKeys<ObjectType extends Record<string, any>>(
+export function excludeKeys<ObjectType extends Record<PropertyKey, any>>(
 	object: ObjectType,
 	predicate: (
 		key: keyof ObjectType,
@@ -67,7 +67,7 @@ export function excludeKeys<ObjectType extends Record<string, any>>(
 	) => boolean
 ): Partial<ObjectType>;
 export function excludeKeys<
-	ObjectType extends Record<string, any>,
+	ObjectType extends Record<PropertyKey, any>,
 	ExcludedKeys extends keyof ObjectType,
 >(
 	object: ObjectType,

--- a/index.js
+++ b/index.js
@@ -3,25 +3,29 @@ export function includeKeys(object, predicate) {
 
 	if (Array.isArray(predicate)) {
 		const set = new Set(predicate);
-		for (const key of Object.keys(object)) {
-			if (set.has(key)) {
+		for (const key of Reflect.ownKeys(object)) {
+			if (isEnumerable.call(object, key) && set.has(key)) {
 				const descriptor = Object.getOwnPropertyDescriptor(object, key);
 				Object.defineProperty(result, key, descriptor);
 			}
 		}
 	} else {
-		// `for ... of Object.keys()` is faster than `for ... of Object.entries()`.
-		for (const key of Object.keys(object)) {
-			const value = object[key];
-			if (predicate(key, value, object)) {
-				const descriptor = Object.getOwnPropertyDescriptor(object, key);
-				Object.defineProperty(result, key, descriptor);
+		// `for ... of Reflect.ownKeys()` is faster than `for ... of Object.entries()`.
+		for (const key of Reflect.ownKeys(object)) {
+			if (isEnumerable.call(object, key)) {
+				const value = object[key];
+				if (predicate(key, value, object)) {
+					const descriptor = Object.getOwnPropertyDescriptor(object, key);
+					Object.defineProperty(result, key, descriptor);
+				}
 			}
 		}
 	}
 
 	return result;
 }
+
+const {propertyIsEnumerable: isEnumerable} = Object.prototype;
 
 export function excludeKeys(object, predicate) {
 	if (Array.isArray(predicate)) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,15 +1,17 @@
 import {expectType, expectError} from 'tsd';
 import {includeKeys, excludeKeys} from './index.js';
 
+const propSymbol = Symbol('test');
 const object = {
 	foo: 'foo',
 	bar: 1,
+	[propSymbol]: true,
 };
 
 expectType<Partial<typeof object>>(
 	includeKeys(object, (key, value) => {
-		expectType<'foo' | 'bar'>(key);
-		expectType<string | number>(value);
+		expectType<'foo' | 'bar' | typeof propSymbol>(key);
+		expectType<string | number | boolean>(value);
 
 		return false;
 	}),
@@ -18,13 +20,14 @@ expectError<typeof object>(
 	includeKeys(object, () => false),
 );
 expectType<{foo: string}>(includeKeys(object, ['foo']));
+expectType<{[propSymbol]: boolean}>(includeKeys(object, [propSymbol]));
 expectError<typeof object>(includeKeys(object, ['foo']));
 expectError(includeKeys(object, ['baz']));
 
 expectType<Partial<typeof object>>(
 	excludeKeys(object, (key, value) => {
-		expectType<'foo' | 'bar'>(key);
-		expectType<string | number>(value);
+		expectType<'foo' | 'bar' | typeof propSymbol>(key);
+		expectType<string | number | boolean>(value);
 
 		return false;
 	}),
@@ -32,6 +35,7 @@ expectType<Partial<typeof object>>(
 expectError<typeof object>(
 	excludeKeys(object, () => false),
 );
-expectType<{bar: number}>(excludeKeys(object, ['foo']));
+expectType<{bar: number; [propSymbol]: boolean}>(excludeKeys(object, ['foo']));
+expectType<{foo: string; bar: number}>(excludeKeys(object, [propSymbol]));
 expectError<typeof object>(excludeKeys(object, ['foo']));
 expectError(excludeKeys(object, ['baz']));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,16 +1,16 @@
 import {expectType, expectError} from 'tsd';
 import {includeKeys, excludeKeys} from './index.js';
 
-const propSymbol = Symbol('test');
+const propertySymbol = Symbol('test');
 const object = {
 	foo: 'foo',
 	bar: 1,
-	[propSymbol]: true,
+	[propertySymbol]: true,
 };
 
 expectType<Partial<typeof object>>(
 	includeKeys(object, (key, value) => {
-		expectType<'foo' | 'bar' | typeof propSymbol>(key);
+		expectType<'foo' | 'bar' | typeof propertySymbol>(key);
 		expectType<string | number | boolean>(value);
 
 		return false;
@@ -20,13 +20,13 @@ expectError<typeof object>(
 	includeKeys(object, () => false),
 );
 expectType<{foo: string}>(includeKeys(object, ['foo']));
-expectType<{[propSymbol]: boolean}>(includeKeys(object, [propSymbol]));
+expectType<{[propertySymbol]: boolean}>(includeKeys(object, [propertySymbol]));
 expectError<typeof object>(includeKeys(object, ['foo']));
 expectError(includeKeys(object, ['baz']));
 
 expectType<Partial<typeof object>>(
 	excludeKeys(object, (key, value) => {
-		expectType<'foo' | 'bar' | typeof propSymbol>(key);
+		expectType<'foo' | 'bar' | typeof propertySymbol>(key);
 		expectType<string | number | boolean>(value);
 
 		return false;
@@ -35,7 +35,7 @@ expectType<Partial<typeof object>>(
 expectError<typeof object>(
 	excludeKeys(object, () => false),
 );
-expectType<{bar: number; [propSymbol]: boolean}>(excludeKeys(object, ['foo']));
-expectType<{foo: string; bar: number}>(excludeKeys(object, [propSymbol]));
+expectType<{bar: number; [propertySymbol]: boolean}>(excludeKeys(object, ['foo']));
+expectType<{foo: string; bar: number}>(excludeKeys(object, [propertySymbol]));
 expectError<typeof object>(excludeKeys(object, ['foo']));
 expectError(excludeKeys(object, ['baz']));

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ A predicate function that determines whether a property should be filtered.
 
 #### keys
 
-Type: `(string | symbol)[]`
+Type: `Array<string | symbol>`
 
 An array of property keys to be filtered.
 

--- a/readme.md
+++ b/readme.md
@@ -33,8 +33,6 @@ const newObject3 = excludeKeys(object, ['bar']);
 
 ## API
 
-Symbol keys are not copied over to the new object.
-
 ### includeKeys(source, filter)
 ### includeKeys(source, keys)
 ### excludeKeys(source, filter)
@@ -48,15 +46,15 @@ The source object to filter properties from.
 
 #### filter
 
-Type: `(sourceKey, sourceValue, source) => boolean`
+Type: `(sourceKey: string | symbol, sourceValue: any, source: object) => boolean`
 
 A predicate function that determines whether a property should be filtered.
 
 #### keys
 
-Type: `string[]`
+Type: `(string | symbol)[]`
 
-An array of property names to be filtered.
+An array of property keys to be filtered.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ The source object to filter properties from.
 
 #### filter
 
-Type: `(sourceKey: string | symbol, sourceValue: any, source: object) => boolean`
+Type: `(sourceKey: string | symbol, sourceValue: unknown, source: object) => boolean`
 
 A predicate function that determines whether a property should be filtered.
 

--- a/test.js
+++ b/test.js
@@ -22,10 +22,10 @@ test('includeKeys: array predicate', t => {
 	t.deepEqual(Object.keys(includeKeys({foo: true, bar: false}, ['foo'])), ['foo']);
 });
 
-test('includeKeys: symbol properties are omitted', t => {
+test('includeKeys: symbol properties are kept', t => {
 	const symbol = Symbol('test');
 	const input = {[symbol]: true};
-	t.is(includeKeys(input, () => true)[symbol], undefined);
+	t.true(includeKeys(input, () => true)[symbol]);
 });
 
 test('includeKeys: non-enumerable properties are omitted', t => {
@@ -75,10 +75,10 @@ test('excludeKeys: array predicate', t => {
 	t.deepEqual(Object.keys(excludeKeys({foo: true, bar: false}, ['bar'])), ['foo']);
 });
 
-test('excludeKeys: symbol properties are omitted', t => {
+test('excludeKeys: symbol properties are kept', t => {
 	const symbol = Symbol('test');
 	const input = {[symbol]: true};
-	t.is(excludeKeys(input, () => false)[symbol], undefined);
+	t.true(excludeKeys(input, () => false)[symbol]);
 });
 
 test('excludeKeys: non-enumerable properties are omitted', t => {


### PR DESCRIPTION
Fixes #21.

This ensures symbol properties are kept.
This is a breaking change since the function predicate passed as argument needs to handle the potential case that the key might be a symbol instead of a string.