### PR TITLE
Use `Object.getOwnPropertyDescriptors()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,22 @@
 export function includeKeys(object, predicate) {
 	const result = {};
+	const descriptors = Object.getOwnPropertyDescriptors(object)
+	const keys = Reflect.ownKeys(descriptors)
 
 	if (Array.isArray(predicate)) {
 		const set = new Set(predicate);
-		for (const key of Reflect.ownKeys(object)) {
-			if (isEnumerable.call(object, key) && set.has(key)) {
-				const descriptor = Object.getOwnPropertyDescriptor(object, key);
+		for (const key of keys) {
+			const descriptor = descriptors[key]
+			if (descriptor.enumerable && set.has(key)) {
 				Object.defineProperty(result, key, descriptor);
 			}
 		}
 	} else {
-		// `for ... of Reflect.ownKeys()` is faster than `for ... of Object.entries()`.
-		for (const key of Reflect.ownKeys(object)) {
-			if (isEnumerable.call(object, key)) {
+		for (const key of keys) {
+			const descriptor = descriptors[key]
+			if (descriptor.enumerable) {
 				const value = object[key];
 				if (predicate(key, value, object)) {
-					const descriptor = Object.getOwnPropertyDescriptor(object, key);
 					Object.defineProperty(result, key, descriptor);
 				}
 			}
@@ -24,8 +25,6 @@ export function includeKeys(object, predicate) {
 
 	return result;
 }
-
-const {propertyIsEnumerable: isEnumerable} = Object.prototype;
 
 export function excludeKeys(object, predicate) {
 	if (Array.isArray(predicate)) {

--- a/index.js
+++ b/index.js
@@ -1,19 +1,19 @@
 export function includeKeys(object, predicate) {
 	const result = {};
-	const descriptors = Object.getOwnPropertyDescriptors(object)
-	const keys = Reflect.ownKeys(descriptors)
+	const descriptors = Object.getOwnPropertyDescriptors(object);
+	const keys = Reflect.ownKeys(descriptors);
 
 	if (Array.isArray(predicate)) {
 		const set = new Set(predicate);
 		for (const key of keys) {
-			const descriptor = descriptors[key]
+			const descriptor = descriptors[key];
 			if (descriptor.enumerable && set.has(key)) {
 				Object.defineProperty(result, key, descriptor);
 			}
 		}
 	} else {
 		for (const key of keys) {
-			const descriptor = descriptors[key]
+			const descriptor = descriptors[key];
 			if (descriptor.enumerable) {
 				const value = object[key];
 				if (predicate(key, value, object)) {


### PR DESCRIPTION
This is a draft PR to discuss https://github.com/sindresorhus/filter-obj/issues/24

This refactors the logic to use `Object.getOwnPropertyDescriptors()`. 

`Object.getOwnPropertyDescriptors()` returns an object that we need to iterate. `for ... in`, `Object.keys()` or `Object.entries()` do not work because they skip symbols. Therefore, `Reflect.ownKeys()` is still needed in order to iterate.

Because of this, from our [benchmarks](https://github.com/sindresorhus/filter-obj/blob/main/benchmark.js), it appears that this change would be roughly twice slower (on my machine). The following table shows a comparison before and after this PR. Each row uses an object with a different amount of properties. The cells are the mean duration per property.

```
                 Before  After
1 property:      408ns   686ns       
10 properties:   184ns   367ns       
1e2 properties:  257ns   532ns       
1e3 properties:  439ns   844ns       
1e4 properties:  325ns   662ns       
1e5 properties:  394ns  1053ns       
1e6 properties:  741ns  1834ns       
```

When it comes to using `Object.defineProperties()` instead of `Object.defineProperty()`, since not all properties are copied, this would require additional intermediate objects and steps, which would most certainly also slow down the logic (I haven't tried it yet though).

If you have any ideas to refactor this PR to make this faster, please let me know! In its current state, it does not seem like this would be an improvement from a performance standpoint.