### PR TITLE
Remove `propertyIsEnumerable()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,18 +3,18 @@ export function includeKeys(object, predicate) {
 
 	if (Array.isArray(predicate)) {
 		for (const key of predicate) {
-			if (isEnumerable.call(object, key)) {
-				const descriptor = Object.getOwnPropertyDescriptor(object, key);
+			const descriptor = Object.getOwnPropertyDescriptor(object, key);
+			if (descriptor !== undefined && descriptor.enumerable) {
 				Object.defineProperty(result, key, descriptor);
 			}
 		}
 	} else {
-		// `for ... of Reflect.ownKeys()` is faster than `for ... of Object.entries()`.
+		// `Reflect.ownKeys()` is required to retrieve symbol properties
 		for (const key of Reflect.ownKeys(object)) {
-			if (isEnumerable.call(object, key)) {
+			const descriptor = Object.getOwnPropertyDescriptor(object, key);
+			if (descriptor.enumerable) {
 				const value = object[key];
 				if (predicate(key, value, object)) {
-					const descriptor = Object.getOwnPropertyDescriptor(object, key);
 					Object.defineProperty(result, key, descriptor);
 				}
 			}
@@ -23,8 +23,6 @@ export function includeKeys(object, predicate) {
 
 	return result;
 }
-
-const {propertyIsEnumerable: isEnumerable} = Object.prototype;
 
 export function excludeKeys(object, predicate) {
 	if (Array.isArray(predicate)) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export function includeKeys(object, predicate) {
 	if (Array.isArray(predicate)) {
 		for (const key of predicate) {
 			const descriptor = Object.getOwnPropertyDescriptor(object, key);
-			if (descriptor !== undefined && descriptor.enumerable) {
+			if (descriptor?.enumerable) {
 				Object.defineProperty(result, key, descriptor);
 			}
 		}


### PR DESCRIPTION
Inspired by https://github.com/sindresorhus/filter-obj/issues/24

This is a small refactoring that uses `Object.getOwnPropertyDescriptor().enumerable` instead of `Object.prototype.propertyIsEnumerable()`. It does not change the behavior, but yields a small performance boost.

The following table shows a comparison before and after this PR. Each row uses an object with a different amount of properties. The cells are the mean duration per property.

```js
Function predicate:
                 Before  After
1 property:      408ns   378ns       
10 properties:   184ns   176ns       
1e2 properties:  257ns   209ns       
1e3 properties:  439ns   386ns       
1e4 properties:  325ns   310ns       
1e5 properties:  394ns   383ns       
1e6 properties:  741ns   737ns       

Array with 100 keys:
                 Before  After
1 property:      308ns   298ns       
10 properties:    59ns    57ns       
1e2 properties:   45ns    38ns       
1e3 properties:   20ns     9ns       
1e4 properties:   20ns    17ns       
1e5 properties:   26ns    22ns       
1e6 properties:   64ns    55ns       
```