### PR TITLE
Improve performance of array predicates

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,8 @@ export function includeKeys(object, predicate) {
 	const result = {};
 
 	if (Array.isArray(predicate)) {
-		const set = new Set(predicate);
-		for (const key of Reflect.ownKeys(object)) {
-			if (isEnumerable.call(object, key) && set.has(key)) {
+		for (const key of predicate) {
+			if (isEnumerable.call(object, key)) {
 				const descriptor = Object.getOwnPropertyDescriptor(object, key);
 				Object.defineProperty(result, key, descriptor);
 			}


### PR DESCRIPTION
This PR improves the performance of array predicates, especially on big objects.

In most situations, the array predicate is much smaller than the object number of properties. This optimizes for that use case by iterating over the array predicate keys instead of over the object properties. Doing so also removes the need to build a `Set()` since `isEnumerable()` already checks for property existence.

The following table shows a comparison before and after this PR. Each row uses an object with a different amount of properties and a predicate of 100 keys. The cells are the mean duration per property.

```js
                 Before     After
1 property:      308ns   265.20ns       
10 properties:    59ns    54.89ns       
1e2 properties:   45ns    36.45ns       
1e3 properties:   20ns     3.99ns       
1e4 properties:   20ns     0.45ns       
1e5 properties:   26ns     0.06ns       
1e6 properties:   64ns     0.03ns       
```

The performance boost for big objects is very high because the performance is now mostly relative to the size of the array predicate instead of the size of the input object.