### PR TITLE
Allow `predicate` to be any iterable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ export function includeKeys<
 	IncludedKeys extends keyof ObjectType,
 >(
 	object: ObjectType,
-	keys: readonly IncludedKeys[]
+	keys: Readonly<Iterable<IncludedKeys>>
 ): Pick<ObjectType, IncludedKeys>;
 
 /**
@@ -71,5 +71,5 @@ export function excludeKeys<
 	ExcludedKeys extends keyof ObjectType,
 >(
 	object: ObjectType,
-	keys: readonly ExcludedKeys[]
+	keys: Readonly<Iterable<ExcludedKeys>>
 ): Omit<ObjectType, ExcludedKeys>;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 export function includeKeys(object, predicate) {
 	const result = {};
 
-	if (Array.isArray(predicate)) {
+	if (isIterable(predicate)) {
 		for (const key of predicate) {
 			const descriptor = Object.getOwnPropertyDescriptor(object, key);
 			if (descriptor?.enumerable) {
@@ -25,10 +25,14 @@ export function includeKeys(object, predicate) {
 }
 
 export function excludeKeys(object, predicate) {
-	if (Array.isArray(predicate)) {
+	if (isIterable(predicate)) {
 		const set = new Set(predicate);
 		return includeKeys(object, key => !set.has(key));
 	}
 
 	return includeKeys(object, (key, value, object) => !predicate(key, value, object));
 }
+
+const isIterable = predicate => typeof predicate === 'object'
+	&& predicate !== null
+	&& typeof predicate[Symbol.iterator] === 'function';

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -20,6 +20,7 @@ expectError<typeof object>(
 	includeKeys(object, () => false),
 );
 expectType<{foo: string}>(includeKeys(object, ['foo']));
+expectType<{foo: string}>(includeKeys(object, new Set(['foo' as const])));
 expectType<{[propertySymbol]: boolean}>(includeKeys(object, [propertySymbol]));
 expectError<typeof object>(includeKeys(object, ['foo']));
 expectError(includeKeys(object, ['baz']));
@@ -36,6 +37,7 @@ expectError<typeof object>(
 	excludeKeys(object, () => false),
 );
 expectType<{bar: number; [propertySymbol]: boolean}>(excludeKeys(object, ['foo']));
+expectType<{bar: number; [propertySymbol]: boolean}>(excludeKeys(object, new Set(['foo' as const])));
 expectType<{foo: string; bar: number}>(excludeKeys(object, [propertySymbol]));
 expectError<typeof object>(excludeKeys(object, ['foo']));
 expectError(excludeKeys(object, ['baz']));

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ A predicate function that determines whether a property should be filtered.
 
 #### keys
 
-Type: `Array<string | symbol>`
+Type: `Iterable<string | symbol>`
 
 An array of property keys to be filtered.
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ A predicate function that determines whether a property should be filtered.
 
 Type: `Iterable<string | symbol>`
 
-An array of property keys to be filtered.
+Property keys to be filtered.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -22,6 +22,10 @@ test('includeKeys: array predicate', t => {
 	t.deepEqual(Object.keys(includeKeys({foo: true, bar: false}, ['foo'])), ['foo']);
 });
 
+test('includeKeys: iterable predicate', t => {
+	t.deepEqual(Object.keys(includeKeys({foo: true, bar: false}, new Set(['foo']))), ['foo']);
+});
+
 test('includeKeys: symbol properties are kept', t => {
 	const symbol = Symbol('test');
 	const input = {[symbol]: true};
@@ -73,6 +77,10 @@ test('excludeKeys: function predicate passes the object as argument', t => {
 
 test('excludeKeys: array predicate', t => {
 	t.deepEqual(Object.keys(excludeKeys({foo: true, bar: false}, ['bar'])), ['foo']);
+});
+
+test('excludeKeys: iterable predicate', t => {
+	t.deepEqual(Object.keys(excludeKeys({foo: true, bar: false}, new Set(['bar']))), ['foo']);
 });
 
 test('excludeKeys: symbol properties are kept', t => {


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/filter-obj/issues/29

This allows `predicate` to be any iterable, e.g. a `Set`.