### PR TITLE
fix: remove the optional chaining grammer

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export function includeKeys(object, predicate) {
 	if (Array.isArray(predicate)) {
 		for (const key of predicate) {
 			const descriptor = Object.getOwnPropertyDescriptor(object, key);
-			if (descriptor?.enumerable) {
+			if (descriptor.enumerable) {
 				Object.defineProperty(result, key, descriptor);
 			}
 		}


### PR DESCRIPTION
The optional chaining grammer seems a little too "modern". In webpack config,  exclude node_modules transpile is a common usage, it's will be better to make this module more compatible.

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/7057473/224767269-3d44eeb4-2278-491a-b556-06005660d953.png">
