### PR TITLE
Fix excludeKeys return type when passing in a union of objects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,4 +72,6 @@ export function excludeKeys<
 >(
 	object: ObjectType,
 	keys: readonly ExcludedKeys[]
-): Omit<ObjectType, ExcludedKeys>;
+): DistributiveOmit<ObjectType, ExcludedKeys>;
+
+type DistributiveOmit<Value, Key extends PropertyKey> = Value extends unknown ? Omit<Value, Key> : never;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -39,3 +39,7 @@ expectType<{bar: number; [propertySymbol]: boolean}>(excludeKeys(object, ['foo']
 expectType<{foo: string; bar: number}>(excludeKeys(object, [propertySymbol]));
 expectError<typeof object>(excludeKeys(object, ['foo']));
 expectError(excludeKeys(object, ['baz']));
+
+type UnionOfObjects = { type: 'foo'; foo: string } | { type: 'bar'; bar: number };
+const object2: UnionOfObjects = { type: 'foo', foo: 'test' } as UnionOfObjects;
+expectType<{ foo: string } | { bar: number }>(excludeKeys(object2, ['type']));


### PR DESCRIPTION
The builtin `Omit` type doesn’t work correctly for union types. Using a [distributive conditional
type](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types) allows to apply the exclusion of the given key(s) for all members of the union.